### PR TITLE
Update to nix 2.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,16 @@ RUN apk add --no-cache --update openssl \
   && echo hosts: dns files > /etc/nsswitch.conf
 
 # Download Nix and install it into the system.
-RUN wget https://nixos.org/releases/nix/nix-2.3/nix-2.3-x86_64-linux.tar.xz \
-  && tar xf nix-2.3-x86_64-linux.tar.xz \
+ARG NIX_VERSION=2.3.4
+RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-x86_64-linux.tar.xz \
+  && tar xf nix-${NIX_VERSION}-x86_64-linux.tar.xz \
   && addgroup -g 30000 -S nixbld \
   && for i in $(seq 1 30); do adduser -S -D -h /var/empty -g "Nix build user $i" -u $((30000 + i)) -G nixbld nixbld$i ; done \
   && mkdir -m 0755 /etc/nix \
   && echo 'sandbox = false' > /etc/nix/nix.conf \
-  && mkdir -m 0755 /nix && USER=root sh nix-*-x86_64-linux/install \
+  && mkdir -m 0755 /nix && USER=root sh nix-${NIX_VERSION}-x86_64-linux/install \
   && ln -s /nix/var/nix/profiles/default/etc/profile.d/nix.sh /etc/profile.d/ \
-  && rm -r /nix-*-x86_64-linux* \
+  && rm -r /nix-${NIX_VERSION}-x86_64-linux* \
   && rm -rf /var/cache/apk/* \
   && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old \
   && /nix/var/nix/profiles/default/bin/nix-store --optimise \


### PR DESCRIPTION
This change also includes an addition of ARG instruction, so the installed nix version could be easily changed via `docker build --build-arg NIX_VERSION=<version>`

Supersedes https://github.com/NixOS/docker/pull/14