### PR TITLE
reduce the size of the base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ addons:
 script:
   - docker build --pull -t nixos/nix .
   - docker run -it --rm nixos/nix nix-channel --list
-  - docker run -it --rm nixos/nix sh -l -c 'nix-env -iA nixpkgs.hello && test "$(hello)" = "Hello, world!"'
+  - docker run -it --rm nixos/nix sh -l -c 'nix-channel --add https://nixos.org/channels/nixpkgs-unstable && nix-channel --update && nix-env -iA nixpkgs.hello && test "$(hello)" = "Hello, world!"'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache --update openssl \
   && echo hosts: dns files > /etc/nsswitch.conf
 
 # Download Nix and install it into the system.
-ARG NIX_VERSION=2.3.4
+ARG NIX_VERSION=2.3.6
 RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-x86_64-linux.tar.xz \
   && tar xf nix-${NIX_VERSION}-x86_64-linux.tar.xz \
   && addgroup -g 30000 -S nixbld \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-x8
   && for i in $(seq 1 30); do adduser -S -D -h /var/empty -g "Nix build user $i" -u $((30000 + i)) -G nixbld nixbld$i ; done \
   && mkdir -m 0755 /etc/nix \
   && echo 'sandbox = false' > /etc/nix/nix.conf \
-  && mkdir -m 0755 /nix && USER=root sh nix-${NIX_VERSION}-x86_64-linux/install \
+  && mkdir -m 0755 /nix && USER=root sh nix-${NIX_VERSION}-x86_64-linux/install --no-channel-add \
   && ln -s /nix/var/nix/profiles/default/etc/profile.d/nix.sh /etc/profile.d/ \
   && rm -r /nix-${NIX_VERSION}-x86_64-linux* \
   && rm -rf /var/cache/apk/* \


### PR DESCRIPTION
Fixes #18 by using `--no-channel-add` option to reduce the size of the base image
    
**This is a breaking change!** Users need to add the following into their Dockerfile files:

    RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable
    RUN nix-channel --update