### PR TITLE
Update the readme to warn users about the missing sandbox.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ Use this build to create your own customized images as follows:
     RUN nix-channel --update
 
     RUN nix-build -A pythonFull '<nixpkgs>'
+
+### Limitations
+
+By default [sandboxing](https://nixos.org/manual/nix/stable/#conf-sandbox) is turned off 
+inside the container, even though it is enabled in new installations of nix. This
+can lead to differences between derivations built inside a docker container versus those built
+without any containerization, especially if a derivation relies on sandboxing to block
+sideloading of dependencies. 
+
+To enable sandboxing the container has to be started with the 
+[`--privileged`](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
+flag and `sandbox = true` set in `/etc/nix/nix.conf`.


### PR DESCRIPTION
This is a follow-up to #26.

