### PR TITLE
Download nix for the host architecture instead of x86_64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,15 @@ RUN apk add --no-cache --update openssl \
 
 # Download Nix and install it into the system.
 ARG NIX_VERSION=2.3.6
-RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-x86_64-linux.tar.xz \
-  && tar xf nix-${NIX_VERSION}-x86_64-linux.tar.xz \
+RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-$(uname -m)-linux.tar.xz \
+  && tar xf nix-${NIX_VERSION}-$(uname -m)-linux.tar.xz \
   && addgroup -g 30000 -S nixbld \
   && for i in $(seq 1 30); do adduser -S -D -h /var/empty -g "Nix build user $i" -u $((30000 + i)) -G nixbld nixbld$i ; done \
   && mkdir -m 0755 /etc/nix \
   && echo 'sandbox = false' > /etc/nix/nix.conf \
-  && mkdir -m 0755 /nix && USER=root sh nix-${NIX_VERSION}-x86_64-linux/install \
+  && mkdir -m 0755 /nix && USER=root sh nix-${NIX_VERSION}-$(uname -m)-linux/install \
   && ln -s /nix/var/nix/profiles/default/etc/profile.d/nix.sh /etc/profile.d/ \
-  && rm -r /nix-${NIX_VERSION}-x86_64-linux* \
+  && rm -r /nix-${NIX_VERSION}-$(uname -m)-linux* \
   && rm -rf /var/cache/apk/* \
   && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old \
   && /nix/var/nix/profiles/default/bin/nix-store --optimise \


### PR DESCRIPTION
This allows building locally for arm64 (see #28 as well).