### PR TITLE
Add git to the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM alpine
 
 # Enable HTTPS support in wget and set nsswitch.conf to make resolution work within containers
-RUN apk add --no-cache --update openssl \
+RUN apk add --no-cache --update openssl git \
   && echo hosts: files dns > /etc/nsswitch.conf
 
 # Download Nix and install it into the system.


### PR DESCRIPTION
This is a pre-requisite for builtins.fetchGit to work. This is
especially painful to deal with if we're using flakes and
flake-compat: we have this nice self-contained set of inputs
but to use them in presence of any git dependencies, we have to first
install git separately.

Fixes #33