### PR TITLE
Switch to GitHub Actions and build for aarch64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,5 +30,6 @@ jobs:
         with:
           build-args: |
             NIX_VERSION=${{ env.NIX_VERSION }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/heads/master') }}
           tags: nixos/nix:${{ env.NIX_VERSION }},nixos/nix:latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+name: Multiarch builds
+on:
+  pull_request:
+  push:
+
+jobs:
+  build-docker-images:
+    runs-on: ubuntu-latest
+    env:
+      NIX_VERSION: 2.3.15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        if: ${{ startsWith(github.ref, 'refs/heads/master') }}
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Images
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            NIX_VERSION=${{ env.NIX_VERSION }}
+          push: ${{ startsWith(github.ref, 'refs/heads/master') }}
+          tags: nixos/nix:${{ env.NIX_VERSION }},nixos/nix:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-$(
   && addgroup -g 30000 -S nixbld \
   && for i in $(seq 1 30); do adduser -S -D -h /var/empty -g "Nix build user $i" -u $((30000 + i)) -G nixbld nixbld$i ; done \
   && mkdir -m 0755 /etc/nix \
-  && echo 'sandbox = false' > /etc/nix/nix.conf \
+  && printf 'filter-syscalls = false\nsandbox = false\n' > /etc/nix/nix.conf \
   && mkdir -m 0755 /nix && USER=root sh nix-${NIX_VERSION}-$(uname -m)-linux/install \
   && ln -s /nix/var/nix/profiles/default/etc/profile.d/nix.sh /etc/profile.d/ \
   && rm -r /nix-${NIX_VERSION}-$(uname -m)-linux* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM alpine
 
 # Enable HTTPS support in wget and set nsswitch.conf to make resolution work within containers
 RUN apk add --no-cache --update openssl git \
+  && rm -rf /var/cache/apk/* \
   && echo hosts: files dns > /etc/nsswitch.conf
 
 # Download Nix and install it into the system.
@@ -14,10 +15,10 @@ RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-$(
   && for i in $(seq 1 30); do adduser -S -D -h /var/empty -g "Nix build user $i" -u $((30000 + i)) -G nixbld nixbld$i ; done \
   && mkdir -m 0755 /etc/nix \
   && printf 'filter-syscalls = false\nsandbox = false\n' > /etc/nix/nix.conf \
-  && mkdir -m 0755 /nix && USER=root sh nix-${NIX_VERSION}-$(uname -m)-linux/install \
+  && mkdir -m 0755 /nix \
+  && sh nix-${NIX_VERSION}-$(uname -m)-linux/install \
   && ln -s /nix/var/nix/profiles/default/etc/profile.d/nix.sh /etc/profile.d/ \
   && rm -r /nix-${NIX_VERSION}-$(uname -m)-linux* \
-  && rm -rf /var/cache/apk/* \
   && /nix/var/nix/profiles/default/bin/nix-collect-garbage --delete-old \
   && /nix/var/nix/profiles/default/bin/nix-store --optimise \
   && /nix/var/nix/profiles/default/bin/nix-store --verify --check-contents

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 This image contains an installation of the [Nix package manager](https://nixos.org/nix/).
 
+The image must be built with [buildkit].
 Use this build to create your own customized images as follows:
+
+[buildkit]: https://docs.docker.com/go/buildkit/
 
 ```Dockerfile
 FROM nixos/nix

--- a/README.md
+++ b/README.md
@@ -2,21 +2,23 @@ This image contains an installation of the [Nix package manager](https://nixos.o
 
 Use this build to create your own customized images as follows:
 
-    FROM nixos/nix
+```Dockerfile
+FROM nixos/nix
 
-    RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
-    RUN nix-channel --update
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
+RUN nix-channel --update
 
-    RUN nix-build -A pythonFull '<nixpkgs>'
+RUN nix-build -A pythonFull '<nixpkgs>'
+```
 
 ### Limitations
 
-By default [sandboxing](https://nixos.org/manual/nix/stable/#conf-sandbox) is turned off 
-inside the container, even though it is enabled in new installations of nix. This
-can lead to differences between derivations built inside a docker container versus those built
-without any containerization, especially if a derivation relies on sandboxing to block
-sideloading of dependencies. 
+By default [sandboxing] is turned off inside the container, even though it is enabled in new installations of nix.
+This can lead to differences between derivations built inside a docker container versus those built without any containerization.
+Differences are especially likely if a derivation relies on sandboxing to block sideloading of dependencies.
 
-To enable sandboxing the container has to be started with the 
-[`--privileged`](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
-flag and `sandbox = true` set in `/etc/nix/nix.conf`.
+[sandboxing]: https://nixos.org/manual/nix/stable/#conf-sandbox
+
+To enable sandboxing the container has to be started with the  [`--privileged`] flag and `sandbox = true` set in `/etc/nix/nix.conf`.
+
+[`--privileged`]: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ RUN nix-build -A pythonFull '<nixpkgs>'
 
 ### Limitations
 
-By default [sandboxing] is turned off inside the container, even though it is enabled in new installations of nix.
-This can lead to differences between derivations built inside a docker container versus those built without any containerization.
+By default both [sandboxing] and `filter-syscalls` is turned off inside the container, even though both are enabled in new installations of nix.
+`sandbox = false` can lead to differences between derivations built inside a docker container versus those built without any containerization.
 Differences are especially likely if a derivation relies on sandboxing to block sideloading of dependencies.
 
 [sandboxing]: https://nixos.org/manual/nix/stable/#conf-sandbox
 
 To enable sandboxing the container has to be started with the  [`--privileged`] flag and `sandbox = true` set in `/etc/nix/nix.conf`.
+To enable syscall filtering the container has to be started with the  [`--privileged`] flag and `filter-syscalls = true` set in `/etc/nix/nix.conf`.
 
 [`--privileged`]: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities


### PR DESCRIPTION
This PR enables building docker images for aarch64 machines. It does this by using `docker buildx`'s [support](https://github.com/docker/buildx/#building-multi-platform-images) for building multarch images.

I'm also transitioning the build from travis to github actions. Is it fine to do it in this PR or should  I split that off into a separate PR that this will block on?

This PR closes #28.