### PR TITLE
Fix link to `sandbox` option in nix.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use this build to create your own customized images as follows:
 
 ### Limitations
 
-By default [sandboxing](https://nixos.org/manual/nix/stable/#conf-sandbox) is turned off 
+By default [sandboxing](https://nixos.org/manual/nix/stable/command-ref/conf-file.html?highlight=sandbox#description) is turned off 
 inside the container, even though it is enabled in new installations of nix. This
 can lead to differences between derivations built inside a docker container versus those built
 without any containerization, especially if a derivation relies on sandboxing to block


### PR DESCRIPTION
The current link is broken. This PR fixes the issue.